### PR TITLE
Improves song parsing, error handling and logging for worship schedul…

### DIFF
--- a/mydiscord.py
+++ b/mydiscord.py
@@ -37,7 +37,7 @@ READ_CHANNEL = os.environ['READCHANNELID']
 POST_CHANNEL = os.environ['POSTCHANNELID']
 set_path = 'sets/'
 bulletin_path = 'bulletin/'
-VERSION = '2.01 - Allegiance'
+VERSION = '2.02 - Andraste'
 
 
 def read_discord():

--- a/mydiscord.py
+++ b/mydiscord.py
@@ -23,7 +23,7 @@ if not os.path.exists('logs/'):
 
 # TODO: Add "Handlers=[]" argument to write to stdout and the file.
 logging.basicConfig(filename='logs/debug.log',
-                    level=logging.DEBUG,
+                    level=logging.INFO,
                     format="%(asctime)s [%(levelname)s] [%(filename)s] --> %(message)s",
                     datefmt='%m/%d/%Y %I:%M:%S %p')
 
@@ -110,17 +110,28 @@ def read_discord():
 
                 # --- parse the incoming Discord message
                 status_message = utils.parsemessage()
+
                 if 'Worship Schedule' in message.content:
                     # Create a list of songs from the text tile.
                     song_list = utils.parse_songs_from_file(bulletin_path + filelist.WorshipScheduleFilename)
-                    # Check to see if the songs are valid.
-                    invalid_songs = utils.validate_songs(song_list, 5)
+                    if type(song_list) != str:
+                        # Check to see if the songs are valid.
+                        invalid_songs = utils.validate_songs(song_list, 5)
 
-                    # Return a message on the song status
-                    for return_message in invalid_songs['embed']:
-                        await client.get_channel(int(READ_CHANNEL)).send(embed=invalid_songs['embed'][return_message])
-                    # Apply any needed case-correction - must pass in the song_list of correct case.
-                    utils.song_case_correction(bulletin_path + filelist.WorshipScheduleFilename, invalid_songs['songs'])
+                        # Return a message on the song status
+                        for return_message in invalid_songs['embed']:
+                            await client.get_channel(int(READ_CHANNEL)) \
+                                .send(embed=invalid_songs['embed'][return_message])
+                        # Apply any needed case-correction - must pass in the song_list of correct case.
+                        utils.song_case_correction(bulletin_path + filelist.WorshipScheduleFilename,
+                                                   invalid_songs['songs'])
+                    else:
+                        logging.error("not able to validate any songs in the worship schedule.")
+                        embed_data = discord.Embed(title="Error!", color=0x2ECC71,
+                                                   description="There were not any songs found in the worship schedule."
+                                                               "Please ensure the formatting is correct and post"
+                                                               "the message again.")
+                        await message.channel.send(embed=embed_data)
 
                 if 'sermon info' in message.content:
                     await message.channel.send(embed=utils.status_embed("sermon info", message))
@@ -131,13 +142,13 @@ def read_discord():
                     await message.channel.send(embed=utils.status_embed("assurance of pardon", message))
 
                 if "Unrecognized" not in status_message:  # --- check if a valid status message was received
-                    #status_message = monitorfiles.statuscheck()  # --- retrieve the current processing status
+                    # status_message = monitorfiles.statuscheck()  # --- retrieve the current processing status
                     print(status_message)
                     await channel.send(embed=utils.convert_embed(status_message))
 
-                #textFile = open(bulletin_path + filelist.DiscordMessageFilename, 'w', encoding='utf-8', errors='ignore')
-                #textFile.writelines(message.content)
-                #textFile.close()
+                # textFile = open(bulletin_path + filelist.DiscordMessageFilename, 'w', encoding='utf-8', errors='ignore')
+                # textFile.writelines(message.content)
+                # textFile.close()
 
                 # --- check if a valid status message was received
                 elif status_message:
@@ -214,29 +225,30 @@ def read_discord():
         description="Copies a new song from OpeonSong  to the website"
     )
     async def add_song(ctx, song_name):
-        status_message = maintainsong.addsong(song_name)   #--- validates song against Dropbox
+        status_message = maintainsong.addsong(song_name)  # --- validates song against Dropbox
         if 'no matching song found' in status_message:
             embed_data = discord.Embed(title="Song Not Found: " + song_name,
-                                description='no matching song found')
+                                       description='no matching song found')
             await ctx.send(embed=embed_data)
-            return()
+            return ()
 
-        else:  
-            song_matches = utils.search_songs(song_name)            #--- validate song name against website
+        else:
+            song_matches = utils.search_songs(song_name)  # --- validate song name against website
             content = ""
             for song in song_matches:
                 content = content + "\n" + "[" + song + "]" + "(" + song_matches[song] + ")"
                 song_name = song
-        
-            if len(song_matches) == 1:      # --- found exact match
+
+            if len(song_matches) == 1:  # --- found exact match
                 status_message = maintainsong.updatesong(song_name)
 
                 embed_data = discord.Embed(title="Update Song ",
-                                   description=content)
+                                           description=content)
                 await ctx.send(embed=embed_data)
             else:
-                embed_data = discord.Embed(title="Found " + str(len(song_matches)) + " possible matche(s) for song: " + song_name,
-                                   description=content)
+                embed_data = discord.Embed(
+                    title="Found " + str(len(song_matches)) + " possible matche(s) for song: " + song_name,
+                    description=content)
                 await ctx.send(embed=embed_data)
 
     @slash.slash(
@@ -244,22 +256,23 @@ def read_discord():
         description="Copies an existing song from OpenSong and SFTPs to the website "
     )
     async def update_song(ctx, song_name):
-        song_matches = utils.search_songs(song_name)            #--- validate song name against website
+        song_matches = utils.search_songs(song_name)  # --- validate song name against website
         content = ""
         for song in song_matches:
             content = content + "\n" + "[" + song + "]" + "(" + song_matches[song] + ")"
             song_name = song
-        
-        if len(song_matches) == 1:      # --- found exact match
-            #song_name = song_matches[song]
+
+        if len(song_matches) == 1:  # --- found exact match
+            # song_name = song_matches[song]
             status_message = maintainsong.updatesong(song_name)
 
             embed_data = discord.Embed(title="Update Song ",
-                                   description=content)
+                                       description=content)
             await ctx.send(embed=embed_data)
         else:
-            embed_data = discord.Embed(title="Found " + str(len(song_matches)) + " possible matche(s) for song: " + song_name,
-                                   description=content)
+            embed_data = discord.Embed(
+                title="Found " + str(len(song_matches)) + " possible matche(s) for song: " + song_name,
+                description=content)
             await ctx.send(embed=embed_data)
 
     @slash.slash(
@@ -292,7 +305,7 @@ def read_discord():
         description="Copies a set from OpenSong / DropBox to the website"
     )
     async def update_set(ctx, set_name):
-        set_matches = maintainsong.updateset(set_name) #--- push the set to the website        
+        set_matches = maintainsong.updateset(set_name)  # --- push the set to the website
 
         content = ""
         error_message = 'not_found'
@@ -300,14 +313,15 @@ def read_discord():
         if error_message in set_matches[0]:
             status_message = '\nUpdate Set:', set_name
             embed_data = discord.Embed(title="Update Set: " + set_name,
-                            description="set not found")
+                                       description="set not found")
             await ctx.send(embed=embed_data)
         else:
             set_matches = maintainsong.displaySet(set_name)
             content = ""
             for sets in set_matches:
                 content = content + "\n" + "[" + sets + "]" + "(" + set_matches[sets] + ")"
-                embed_data = discord.Embed(title="Found " + str(len(set_matches)) + " possible matche(s).", description=content)
+                embed_data = discord.Embed(title="Found " + str(len(set_matches)) + " possible matche(s).",
+                                           description=content)
                 await ctx.send(embed=embed_data)
 
     @slash.slash(
@@ -320,7 +334,7 @@ def read_discord():
     # -----------------------------------#
     #     Start the discord bot.         #
     # -----------------------------------#
-    #client.run(os.environ['DISCORD_TOKEN'])
+    # client.run(os.environ['DISCORD_TOKEN'])
 
     # --- Start the bot
     client.run(os.environ['DISCORD_TOKEN'])  # --- logon token retrieved from .env variable

--- a/utils.py
+++ b/utils.py
@@ -23,26 +23,30 @@ def parse_songs_from_file(worship_schedule):
     with open(worship_schedule) as file:
         worship_text = file.readlines()
     # Find the line with songs in the array. Assume everything after is a song per line.
-    formatted_song_list = []
+    formatted_song_list = "No songs found."
 
-    try:
-        worship_text.index('Songs\n')
-    except ValueError as error:
+    for index, line in enumerate(worship_text):
+        if 'songs' in line.lower():
+            song_start = index
+            formatted_song_list = []
+            for index2, song in enumerate(worship_text):
+                # Build a list of elements after "Songs" is found.
+                if "Hymn:" in song:
+                    if song.startswith("Hymn:"):
+                        stripped_song = song.rsplit("-", 1)
+                        stripped_song = stripped_song[0].strip("Hymn:")
+                        formatted_song_list.append(stripped_song.strip())
+                if index2 > song_start:
+                    stripped_song = song.rsplit("-", 1)
+                    stripped_song = stripped_song[0].strip("* ")
+                    formatted_song_list.append(stripped_song)
 
-        return 'No songs found.'
-    for index, song in enumerate(worship_text):
-        # Build a list of elements after "Songs" is found.
-        if "Hymn:" in song:
-            if song.startswith("Hymn:"):
-                stripped_song = song.rsplit("-", 1)
-                stripped_song = stripped_song[0].strip("Hymn:")
-                formatted_song_list.append(stripped_song.strip())
-        if index > worship_text.index('Songs\n'):
-            stripped_song = song.rsplit("-", 1)
-            stripped_song = stripped_song[0].strip("* ")
-            formatted_song_list.append(stripped_song)
-
-    return formatted_song_list
+    if len(formatted_song_list) <= 1:
+        logging.warning("Not enough sounds were found when parsing {file}".format(file=worship_schedule))
+        logging.warning(worship_text)
+        return "Not enough songs have were found.."
+    else:
+        return formatted_song_list
 
 
 # Takes in a list of songs.
@@ -220,7 +224,7 @@ def song_case_correction(song_file, song_list):
         for song in song_list:
             if song.lower() in line.lower():
                 file_text[index] = re.sub(song, song, file_text[index], flags=re.IGNORECASE)
-                logging.info("Updating the song-case of " + song)
+                logging.warning("Updating the song-case of " + song)
     with open(song_file, 'w') as file:
         file.writelines(file_text)
         file.close()
@@ -367,7 +371,6 @@ def read_ahead(my_list):
 # --- Parse the incoming Discord message
 def parsemessage():
     import filelist
-    from readworshipschedule import readWS
 
     bulletin_path = 'bulletin/'
     status_message = []
@@ -525,7 +528,6 @@ def read_ahead(my_list):
 # --- Parse the incoming Discord message
 def parsemessage():
     import filelist
-    from readworshipschedule import readWS
 
     bulletin_path = 'bulletin/'
     status_message = []


### PR DESCRIPTION
Resolves #104

This error is caused when using discord formatting in the post message for example:

> \*\*Songs\*\*
> \* Is He Worthy? - V1 V2 C1 V3 C2 E
> \* Turn Your Eyes - V1 V2 C V3 C V4 C C E
> \* Who You Say I Am - V1 C1 V2 C2 B B T C2 E

shows as: 
> **Songs**
> \* Is He Worthy? - V1 V2 C1 V3 C2 E
> \* Turn Your Eyes - V1 V2 C V3 C V4 C C E
> \* Who You Say I Am - V1 C1 V2 C2 B B T C2 E

When no songs can be found after parsing the worship schedule file, the parse function returns a "No songs found" string as the "song_list" that is passed into our song validator. The song validator iterates through this with each letter being an index in the string array.

I've added additional logging for us to troubleshoot, and changed the way the song parsing is handled. It should now accept discord formatting since it now looks for the word "songs" within the line it's parsing and sets that line as the starting index.

When validating the songs, we now check for the variable "type" and if string is passed, we assume no songs can be found and return an error message.