### PR TITLE
fixed_sermon_parse_issue

### DIFF
--- a/maintainsong.py
+++ b/maintainsong.py
@@ -211,7 +211,7 @@ def bs4buildSetSummary(SetName='2021-04-04 GCCEM Sunday Worship'):
 
     doctree = ET.parse(datasource)
     root = doctree.getroot()
-    print('\nBS4BuildSet - the number of slide_groups in the set: ', len(root[0]))
+    #print('\nBS4BuildSet - the number of slide_groups in the set: ', len(root[0]))
    
     fd = open(local_set_name, 'r', errors='ignore')
     xml_file = fd.read()

--- a/my_test_routine.py
+++ b/my_test_routine.py
@@ -87,11 +87,17 @@ def task_trigger():
 #--- main routine to unit test independent functions
 def main():
     import downloadbulletin
+    import opensong
     from getdatetime import nextSunday
     import maintainsong
     from stringsplit import convertListToStringWithNewLine, convertListToString
 
     print('\nMy Test Routine - Start Test!\n')
+
+    status_message = opensong.assembleset()
+    print('Assemble Set processing complete', status_message)
+    
+    return
 
     status_message = convertListToString()
 

--- a/opensong.py
+++ b/opensong.py
@@ -31,7 +31,7 @@ def assembleset():
     doctree = ET.parse(datasource)
     root = doctree.getroot()
     print('\nAssembleSet - the number of slide_groups in the set: ', len(root[0]))
-
+ 
     # -------------- call the process files function to process the files with the extracted bulletin information
     status_message = processfiles(doctree)  # --- pass the XML set document tree
 
@@ -44,6 +44,8 @@ def assembleset():
 def processfiles(doctree):
     import addnode
     import processAffirmationOfFaith
+    import re
+    import utils
 
     # -------------- Read the contents of the Call To Worship text file -----------------------------
     slide_group_name = 'Call to Worship'
@@ -51,20 +53,24 @@ def processfiles(doctree):
 
     addnode.addbodyslides(doctree, slide_group_name, body_text)  # --- call the add confession text function
 
-    # -------------- Read the contents of the Bulletin Sermon  text file -----------------------------
-    textFile = open(bulletin_path + filelist.BulletinSermonFilename, 'r', encoding='utf-8', errors='ignore')
-    body_text = textFile.read()  # --- read the file into a string
-    # print(body_text)
-
+    # -------------- process the sermon information -----------------------------
     slide_group_name = 'Sermon'
     addnode.addbodytext(doctree, slide_group_name, body_text)  # --- call the addbodytext function
 
-    # -- Add the Sermon Scripture to the XML document
-    scripture = body_text.splitlines()
-    scripture_ref = scripture[1].strip()
-    #print('\nOpenSong.processfiles - Sermon Scripture Reference=', scripture_ref)
-    addnode.addscripture(doctree, slide_group_name, scripture_ref)
+     # -------------- Read the contents of the Bulletin Sermon  text file -----------------------------
+    scripture_ref, sermon_title = utils.extract_sermon_info()
+    sermon_info = sermon_title + '\n' + scripture_ref
+    slide_group_name = 'Sermon'
 
+    addnode.addbodytext(doctree, slide_group_name, sermon_info)  # --- call the addbodytext function
+
+    # -- Add the Sermon Scripture to the XML document
+    #scripture = body_text.splitlines()
+    #scripture_ref = scripture[1].strip()
+    #scripture_ref = '1 Cor. 12:4–31'    #for testing
+    #scripture_ref, body_text = utils.extract_sermon_scripture()
+
+    addnode.addscripture(doctree, slide_group_name, scripture_ref)
     # -------------- Process the contents of the Confession of Sin text file -----------------------------
     slide_group_name = 'Confession of Sin'
 
@@ -231,7 +237,6 @@ def writeXMLSet(doctree):
     myroot = doctree.getroot()  # --- XML document tree passed as a parameter
 
     myroot.attrib = {'name': setNameAttrib}  # --- assign the set name attribute
-    print(myroot.tag, myroot.attrib)
 
     # --- End of processing - write out the modified worship set
 

--- a/utils.py
+++ b/utils.py
@@ -244,6 +244,7 @@ def parse_passages(input_passages):  # --- input is a scripture reference string
     book = ''
     chapter = ''
     scripture = ''
+    print('Parse_Passage=', input_passages)
     for p in passages:
         p = p.strip()
         if ' ' in p:  # --- indicates a references includes book; e.g. 'john '
@@ -546,3 +547,24 @@ def status_embed(description, message):
                     value=message.author,
                     inline=True)
     return embed
+
+
+def extract_sermon_info():
+    import filelist  # --- definition of list of files and directories used in the proces
+    bulletin_path = 'bulletin/'
+ # -------------- Read the contents of the Bulletin Sermon  text file -----------------------------
+    textFile = open(bulletin_path + filelist.BulletinSermonFilename, 'r', encoding='utf-8', errors='ignore')
+    body_text = textFile.read()  # --- read the file into a string
+
+    line_split = re.split("[“”\n]", body_text)      #split the string into a list
+    sermon_title = line_split[1]
+    
+    # find the possible scripture reference matches
+    matches = [match for match in line_split if ":" in match]
+    if len(matches) > 0:        #match found on possible scripture ref
+        scripture_ref = str(matches[0])      #select the first match
+        return(scripture_ref, sermon_title)
+    else:
+        status_message = ('Extract Scripture Reference failed - invalid scripture reference:', body_text)
+        print(status_message)
+        return(status_message) 

--- a/writehtml.py
+++ b/writehtml.py
@@ -158,13 +158,14 @@ def buildhtmlcontent():
 def buildSermonScriptureContent():
     import passagelookup
     import stringsplit
-    # -------------- Read the contents of the Bulletin Sermon  text file -----------------------------
+    import utils
+ 
     print('\nStarting BuildSermonScriptureContent')
 
-    textFile = open(bulletin_path + filelist.BulletinSermonFilename, 'r', encoding='utf-8', errors='ignore')
-    text_lines = textFile.readlines()  # --- read the file into a list
-    textFile.close()
-    scripture_ref = text_lines[1]
+    # -- retrieve the sermon scripture from the sermon text file
+    scripture_ref, sermon_title = utils.extract_sermon_info()  
+    if "failed" in scripture_ref:
+        return()
 
     # --- FOR TESTING - OVERRIDE WITH DEFAULT VALUE
     # scripture_ref = 'Galatians 2:1–10; John 3:16'


### PR DESCRIPTION
Fix sermon file parse issue due to change in input format.
Sermon title and scripture reference are now on the same line in the file.