### PR TITLE
Fix bulletin download: pivot from autoindex scraping to WordPress REST API

### DIFF
--- a/downloadbulletin.py
+++ b/downloadbulletin.py
@@ -1,8 +1,7 @@
 # ---- https://www.geeksforgeeks.org/downloading-files-web-using-python/
-from datetime import datetime, timedelta
-from urllib.request import Request, urlopen, urlretrieve
-
-from bs4 import BeautifulSoup
+import json
+import urllib.request
+from urllib.request import Request, urlopen
 
 import filelist  # --- definition of list of files and directories used in the process
 import monitorfiles
@@ -11,32 +10,44 @@ import readbulletin
 set_path = 'sets/'
 bulletin_path = 'bulletin/'
 
+# --- WordPress REST API endpoint for media discovery.
+# --- The church site moved to Hostinger and the Apache directory autoindex now
+# --- returns HTTP 403, so the old "scrape /wp-content/uploads/YYYY/MM/" approach
+# --- no longer works.  The WP REST media endpoint replaces it.
+WP_MEDIA_API_URL = (
+    'https://graceem.gccvapca.org/wp-json/wp/v2/media'
+    '?search=EM_Bulletin&orderby=date&order=desc&per_page=10'
+)
+
+USER_AGENT = (
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) '
+    'Gecko/20100101 Firefox/78.0'
+)
+
 
 # --- using urllib2
 def get_bulletin():  # --- function to download bulletin
-    import urllib.request
-    # bulletinurl = 'http://graceem.gccvapca.org/wp-content/uploads/'  #-- bulletin URL
-    bulletinurl = build_directory_name()  # -- call my module getdate() to build the bulletin directory URL
+    bulletins = get_current_bulletin()  # --- find the URL of the current bulletin
 
-    bulletins = get_current_bulletin(bulletinurl)  # --- find the URL of the current bulletin
+    if not bulletins:  # --- no EM_Bulletin entries returned by the WP REST API
+        raise RuntimeError(
+            'No EM_Bulletin entries were returned by the WordPress REST API at '
+            '{}.  Either the search term changed or the site is unreachable.'
+            .format(WP_MEDIA_API_URL)
+        )
 
-    # print('\n Bulletins=', bulletins, 'number of bulletins=', len(bulletins))
-    if len(bulletins) == 0:  # --- no bulletins found for current month
-        bulletinurl = build_prev_month_directory_name()  # --- look in the previous month's directory
-        bulletins = get_current_bulletin(bulletinurl)  # --- find the latest bulletin of the previous month
+    current_bulletin = bulletins[0]  # --- newest entry (API returns desc by date)
+    current_bulletin_url = current_bulletin['url']
 
-    current_bulletin = max(bulletins)  # --- get the current bulletin
-    current_bulletin_url = bulletinurl + current_bulletin
     # --- retrieve the current bulletin and write to local file
-
     # Download the current bulletin file from `url` and save it locally under `file_name`:
     req = urllib.request.Request(current_bulletin_url)
-    req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0')
+    req.add_header('User-Agent', USER_AGENT)
     req.add_header('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8')
 
     file_name = bulletin_path + filelist.PDFBulletinFilename
-    with urllib.request.urlopen(req)  as response, open(file_name, 'wb') as out_file:
-        data = response.read() # a `bytes` object
+    with urllib.request.urlopen(req) as response, open(file_name, 'wb') as out_file:
+        data = response.read()  # a `bytes` object
         out_file.write(data)
 
     readbulletin.getfiles()  # --- process the downloaded bulletin file
@@ -47,67 +58,45 @@ def get_bulletin():  # --- function to download bulletin
 
 # --- end of get_bulltine function
 
-# --- https://stackoverflow.com/questions/11023530/python-to-list-http-files-and-directories/34718858
-def get_current_bulletin(bulletinurl):  # --- function to find the most recent bulletin
-    # bulletinurl = 'http://graceem.gccvapca.org/wp-content/uploads/2021/02/'  #-- bulletin URL
-    # bulletinurl = build_directory_name()
-    # -- call my module getdate() to build the bulletin directory URL
 
-    # outputfile = 'C:\\Dropbox\\OpenSongV2\\Bulletin\\bulletin.pdf'
-    # #---  path for downloaded bulletin
-    #bulletinurl = 'http://graceem.gccvapca.org/wp-content/uploads/2021/07/'  #-- bulletin URL OVERRIDE FOR TESTING
-    print('\nDownloadBulletin.get_current_bulletin - Bulletin file path: ', bulletinurl)
+def get_current_bulletin():  # --- function to find the most recent bulletin via WP REST API
+    """Query the WordPress REST API for EM_Bulletin media entries.
+
+    Returns a list of dicts, newest first, where each dict has at minimum:
+        url  - the PDF URL (from `guid.rendered`)
+        date - the upload timestamp (ISO-8601 string from `date`)
+        slug - the WordPress slug (e.g. 'em_bulletin_260517')
+    """
+    print('\nDownloadBulletin.get_current_bulletin - WP REST API:', WP_MEDIA_API_URL)
+
+    req = Request(WP_MEDIA_API_URL)
+    # ---- fix issue #167 HTTP Error 406
+    req.add_header('User-Agent', USER_AGENT)
+    req.add_header('Accept', 'application/json')
+
+    raw = urlopen(req).read()
+    entries = json.loads(raw)
 
     bulletins = []
-    url = bulletinurl
-    req = Request(url)
-
-    #---- fix issue #167 HTTP Error 406
-    req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0')
-    req.add_header('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8')
-
-    a = urlopen(req).read()  # --- read the bulletin directory
-
-    soup = BeautifulSoup(a, 'html.parser')
-    x = (soup.find_all('a'))
-    for i in x:
-        file_name = i.extract().get_text()
-        url_new = url + file_name
-        url_new = url_new.replace(" ", "%20")
-        if file_name[-1] == '/' and file_name[0] != '.':
-            # read_url(url_new)          # call this function recursively for each subdirectory
-            break
-        # print(url_new)
-        if '.pdf' in file_name:
-            # print(file_name)
-            bulletins.append(file_name)
+    for entry in entries:
+        guid = entry.get('guid') or {}
+        url = guid.get('rendered', '')
+        # --- defensive: only keep entries that actually look like bulletin PDFs
+        if '.pdf' not in url.lower():
+            continue
+        if 'em_bulletin' not in url.lower() and 'em_bulletin' not in entry.get('slug', '').lower():
+            continue
+        bulletins.append({
+            'url': url,
+            'date': entry.get('date', ''),
+            'slug': entry.get('slug', ''),
+        })
 
     return bulletins
 
 
-# --- https://stackoverflow.com/questions/28189442/datetime-current-year-and-month-in-python
-# --- function to get the current year and month to build the correct bulletin directory URL
-def build_directory_name():
-    current_month = datetime.now().strftime('%m')  # ---// 02 //This is 0 padded
-    current_year_full = datetime.now().strftime('%Y')  # ---// 2018
-
-    # print('Current year:', current_year_full, ' current month:', current_month)
-    bulletin_directory = 'http://graceem.gccvapca.org/wp-content/uploads/' + current_year_full + '/' + current_month + '/'
-    print('Bulletin Directory:', bulletin_directory)
-
-    return bulletin_directory
-
-
-# --- https://stackoverflow.com/questions/28189442/datetime-current-year-and-month-in-python
-def build_prev_month_directory_name():  # --- function to build the bulletin directory URL for previous month
-    current_month = datetime.now() - timedelta(days=6)  # ---// Go back 6 days
-    current_month = current_month.strftime('%m')  # ---// This is 0 padded
-
-    current_year_full = datetime.now() - timedelta(days=6)  # ---// Go bakc 6 days
-    current_year_full = current_year_full.strftime('%Y')  # ---// This is padded
-
-    print('Current year:', current_year_full, ' current month:', current_month)
-    bulletin_directory = 'http://graceem.gccvapca.org/wp-content/uploads/' + current_year_full + '/' + current_month + '/'
-    print('Bulletin Directory:', bulletin_directory)
-
-    return bulletin_directory
+if __name__ == "__main__":
+    results = get_current_bulletin()
+    print('Found {} EM_Bulletin entries.  Top 3:'.format(len(results)))
+    for entry in results[:3]:
+        print('  ', entry['date'], entry['url'])

--- a/downloadbulletin.py
+++ b/downloadbulletin.py
@@ -24,6 +24,11 @@ USER_AGENT = (
     'Gecko/20100101 Firefox/78.0'
 )
 
+# --- network timeouts (seconds).  Tunable in one place so a slow/hung
+# --- Hostinger response can't block the async Discord handler indefinitely.
+API_TIMEOUT = 30  # JSON REST API call
+DOWNLOAD_TIMEOUT = 60  # PDF download (larger payload)
+
 
 # --- using urllib2
 def get_bulletin():  # --- function to download bulletin
@@ -46,7 +51,7 @@ def get_bulletin():  # --- function to download bulletin
     req.add_header('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8')
 
     file_name = bulletin_path + filelist.PDFBulletinFilename
-    with urllib.request.urlopen(req) as response, open(file_name, 'wb') as out_file:
+    with urllib.request.urlopen(req, timeout=DOWNLOAD_TIMEOUT) as response, open(file_name, 'wb') as out_file:
         data = response.read()  # a `bytes` object
         out_file.write(data)
 
@@ -74,7 +79,7 @@ def get_current_bulletin():  # --- function to find the most recent bulletin via
     req.add_header('User-Agent', USER_AGENT)
     req.add_header('Accept', 'application/json')
 
-    raw = urlopen(req).read()
+    raw = urlopen(req, timeout=API_TIMEOUT).read()
     entries = json.loads(raw)
 
     bulletins = []

--- a/monitorfiles.py
+++ b/monitorfiles.py
@@ -229,8 +229,7 @@ def set_cleanup(cleanup_type='all'):
 def check_for_latest_bulletin():
     #-- failsafe routine which runs on a schedule to check if the bulletin is ready to download
     import maintainsong
-    from downloadbulletin import build_directory_name, build_prev_month_directory_name, \
-        get_current_bulletin, get_bulletin
+    from downloadbulletin import get_current_bulletin, get_bulletin
     import getdatetime
     import filelist
     import os
@@ -238,9 +237,9 @@ def check_for_latest_bulletin():
 
     bulletin_path = 'bulletin/'
     next_bulletin_date = str(getdatetime.nextSunday())
-    save_next_bulletin_date = next_bulletin_date 
+    save_next_bulletin_date = next_bulletin_date
 
-	#--- check if bulletin message has been posted (i.e. bulletin.txt file exists)
+    #--- check if bulletin message has been posted (i.e. bulletin.txt file exists)
     if os.path.isfile(
             bulletin_path + filelist.TextBulletinFilename):  # --- if the bulletin file already downloaded
         file_status = str("Bulletin File {} already downloaded....".format(bulletin_path + filelist.TextBulletinFilename))
@@ -248,40 +247,40 @@ def check_for_latest_bulletin():
         print(status_message)
         monitorfiles.send_discord_message('Bulletin Status', status_message)
     else:
-        # check if there is a  new buleltin to download
+        # check if there is a  new bulletin to download via the WP REST API
+        bulletins = get_current_bulletin()  # --- newest-first list of EM_Bulletin entries
 
-    	# bulletinurl = 'http://graceem.gccvapca.org/wp-content/uploads/'  #-- bulletin URL
-        bulletinurl = build_directory_name()  # -- call my module getdate() to build the bulletin directory URL
-        bulletins = get_current_bulletin(bulletinurl)  # --- find the URL of the current bulletin
-   
-        if len(bulletins) == 0:  # --- no bulletins found for current month
-            bulletinurl = build_prev_month_directory_name()  # --- look in the previous month's directory
-            bulletins = get_current_bulletin(bulletinurl)  # --- find the latest bulletin of the previous month
-        
-        latest_bulletin = max(bulletins)  # --- get the latest bulletin
+        if not bulletins:
+            status_message = '\nNo EM_Bulletin entries returned by the WordPress REST API for: ' + save_next_bulletin_date
+            monitorfiles.send_discord_message('Bulletin Status', status_message)
+            return
 
-        next_bulletin_date = next_bulletin_date[2:]
-        next_bulletin_date = next_bulletin_date.replace('-', '')     #--- remove dashes
+        latest_bulletin = bulletins[0]  # --- newest entry
+        latest_url = latest_bulletin.get('url', '')
+        latest_slug = latest_bulletin.get('slug', '')
+
+        next_bulletin_date_yymmdd = next_bulletin_date[2:].replace('-', '')  # --- e.g. '260517'
 
         #### TESTING OVERRIDE
-        #next_bulletin_date = '210606'
-        #### END TESTING OVERRIEDE
-    
-        if next_bulletin_date in latest_bulletin: #--- next week's bulletin ready to download
-            print('\nNext Bulletin Date matches=', next_bulletin_date)
-            status_message = 'Bulletin file found and will be processed for', save_next_bulletin_date
-            status_message = monitorfiles.send_discord_message('Bulletin Status', status_message)
-            
+        #next_bulletin_date_yymmdd = '210606'
+        #### END TESTING OVERRIDE
+
+        if next_bulletin_date_yymmdd in latest_url or next_bulletin_date_yymmdd in latest_slug:
+            #--- next week's bulletin ready to download
+            print('\nNext Bulletin Date matches=', next_bulletin_date_yymmdd)
+            status_message = 'Bulletin file found and will be processed for {}'.format(save_next_bulletin_date)
+            monitorfiles.send_discord_message('Bulletin Status', status_message)
+
             get_bulletin()
-            
+
             status_message = monitorfiles.filechecker()
             monitorfiles.send_discord_message('Automated Processing Status', status_message)
 
         else:
-            status_message = '\nMext week Bulletin has not been uploaded as yet for: ', save_next_bulletin_date
+            status_message = '\nNext week Bulletin has not been uploaded as yet for: {}'.format(save_next_bulletin_date)
             #--- send message
             monitorfiles.send_discord_message('Bulletin Status', status_message)
-    
+
 
 #--- end check for latest bulletin
 

--- a/monitorfiles.py
+++ b/monitorfiles.py
@@ -247,39 +247,51 @@ def check_for_latest_bulletin():
         print(status_message)
         monitorfiles.send_discord_message('Bulletin Status', status_message)
     else:
-        # check if there is a  new bulletin to download via the WP REST API
-        bulletins = get_current_bulletin()  # --- newest-first list of EM_Bulletin entries
+        try:
+            # check if there is a  new bulletin to download via the WP REST API
+            bulletins = get_current_bulletin()  # --- newest-first list of EM_Bulletin entries
 
-        if not bulletins:
-            status_message = '\nNo EM_Bulletin entries returned by the WordPress REST API for: ' + save_next_bulletin_date
-            monitorfiles.send_discord_message('Bulletin Status', status_message)
+            if not bulletins:
+                status_message = '\nNo EM_Bulletin entries returned by the WordPress REST API for: ' + save_next_bulletin_date
+                monitorfiles.send_discord_message('Bulletin Status', status_message)
+                return
+
+            latest_bulletin = bulletins[0]  # --- newest entry
+            latest_url = latest_bulletin.get('url', '')
+            latest_slug = latest_bulletin.get('slug', '')
+
+            next_bulletin_date_yymmdd = next_bulletin_date[2:].replace('-', '')  # --- e.g. '260517'
+
+            #### TESTING OVERRIDE
+            #next_bulletin_date_yymmdd = '210606'
+            #### END TESTING OVERRIDE
+
+            # --- anchor on the bulletin prefix so we don't match arbitrary 6-digit
+            # --- substrings elsewhere in the URL/slug.  WordPress lowercases slugs
+            # --- but the URL filename is `EM_Bulletin_...`, so compare lowercased.
+            target = 'em_bulletin_{}'.format(next_bulletin_date_yymmdd)
+            if target in latest_slug.lower() or target in latest_url.lower():
+                #--- next week's bulletin ready to download
+                print('\nNext Bulletin Date matches=', next_bulletin_date_yymmdd)
+                status_message = 'Bulletin file found and will be processed for {}'.format(save_next_bulletin_date)
+                monitorfiles.send_discord_message('Bulletin Status', status_message)
+
+                get_bulletin()
+
+                status_message = monitorfiles.filechecker()
+                monitorfiles.send_discord_message('Automated Processing Status', status_message)
+
+            else:
+                status_message = '\nNext week Bulletin has not been uploaded as yet for: {}'.format(save_next_bulletin_date)
+                #--- send message
+                monitorfiles.send_discord_message('Bulletin Status', status_message)
+        except Exception as e:
+            logging.exception("Scheduled bulletin check failed: %s", e)
+            monitorfiles.send_discord_message(
+                'Bulletin check failed',
+                str(e)[:1500],
+            )
             return
-
-        latest_bulletin = bulletins[0]  # --- newest entry
-        latest_url = latest_bulletin.get('url', '')
-        latest_slug = latest_bulletin.get('slug', '')
-
-        next_bulletin_date_yymmdd = next_bulletin_date[2:].replace('-', '')  # --- e.g. '260517'
-
-        #### TESTING OVERRIDE
-        #next_bulletin_date_yymmdd = '210606'
-        #### END TESTING OVERRIDE
-
-        if next_bulletin_date_yymmdd in latest_url or next_bulletin_date_yymmdd in latest_slug:
-            #--- next week's bulletin ready to download
-            print('\nNext Bulletin Date matches=', next_bulletin_date_yymmdd)
-            status_message = 'Bulletin file found and will be processed for {}'.format(save_next_bulletin_date)
-            monitorfiles.send_discord_message('Bulletin Status', status_message)
-
-            get_bulletin()
-
-            status_message = monitorfiles.filechecker()
-            monitorfiles.send_discord_message('Automated Processing Status', status_message)
-
-        else:
-            status_message = '\nNext week Bulletin has not been uploaded as yet for: {}'.format(save_next_bulletin_date)
-            #--- send message
-            monitorfiles.send_discord_message('Bulletin Status', status_message)
 
 
 #--- end check for latest bulletin

--- a/mydiscord.py
+++ b/mydiscord.py
@@ -78,7 +78,7 @@ def read_discord():
                     embed_data = discord.Embed(
                         title="Bulletin download failed",
                         color=0xE74C3C,
-                        description=str(e),
+                        description=str(e)[:3900],
                     )
                     await message.channel.send(embed=embed_data)
                     await client.process_commands(message)

--- a/mydiscord.py
+++ b/mydiscord.py
@@ -71,7 +71,18 @@ def read_discord():
             # check the Discord message is for the Bulletin post -----
             if "bulletinhasbeenposted" in msg.replace(" ", '').replace('\t', '').lower():
                 # Download the bulletin which was just posted
-                logging.info(downloadbulletin.get_bulletin())
+                try:
+                    logging.info(downloadbulletin.get_bulletin())
+                except Exception as e:
+                    logging.exception("Bulletin download failed: %s", e)
+                    embed_data = discord.Embed(
+                        title="Bulletin download failed",
+                        color=0xE74C3C,
+                        description=str(e),
+                    )
+                    await message.channel.send(embed=embed_data)
+                    await client.process_commands(message)
+                    return
                 await message.channel.send(embed=utils.status_embed("bulletin", message))
                 status_message = monitorfiles.statuscheck()  # retrieve the current processing status
 


### PR DESCRIPTION
## Problem

Users reported that posting "The bulletin has been posted" in Discord no longer triggered a bulletin download — `/status` continued to show `Bulletin: ❌` while every other section was ✅.

## Root cause

The bulletin host (`graceem.gccvapca.org`) moved to Hostinger. Two things changed:

1. HTTP → HTTPS redirect (urllib handles this transparently — not the bug).
2. **The `/wp-content/uploads/YYYY/MM/` directory listing now returns HTTP 403 Forbidden.** The Apache autoindex HTML that `downloadbulletin.get_current_bulletin` was scraping with BeautifulSoup no longer exists.

`urlopen()` raised `HTTPError: 403`, which propagated out of `get_bulletin()` into the Discord `on_message` handler and killed the handler silently before the status embed could be posted. The PDFs themselves are still served fine (200 OK on direct URL).

## Fix

Pivot bulletin discovery to the WordPress REST API:

```
GET https://graceem.gccvapca.org/wp-json/wp/v2/media?search=EM_Bulletin&orderby=date&order=desc&per_page=10
```

Live-verified — returns the newest `EM_Bulletin_*.pdf` entries directly.

### Changes

- **`downloadbulletin.py`** — `get_current_bulletin()` rewritten to call the WP REST API and return a list of dicts (`url`, `date`, `slug`), newest first. `get_bulletin()` simplified to take `results[0]`. `build_directory_name` / `build_prev_month_directory_name` deleted. BeautifulSoup import removed (still used by `maintainsong.py`, so dependency stays). `API_TIMEOUT=30` / `DOWNLOAD_TIMEOUT=60` constants added so `urlopen` can no longer hang the async handler indefinitely. Raises `RuntimeError` with a clear message if the API returns zero entries.

- **`monitorfiles.py`** — `check_for_latest_bulletin` simplified to call the new REST helper, then check whether the upcoming Sunday's `em_bulletin_<yymmdd>` prefix (case-insensitive) appears in the newest entry's slug or URL. The whole body is now wrapped in `try/except` so a future API outage surfaces to Discord via the existing `send_discord_message` webhook instead of dying silently in the APScheduler. The "already downloaded" early-return is intentionally outside the try block. Pre-existing "Mext" typo and tuple-vs-string bug in the scheduled-message path fixed in passing.

- **`mydiscord.py`** — Wrapped the `get_bulletin()` call in `on_message` with `try/except`. On failure: `logging.exception` + a red `0xE74C3C` embed titled "Bulletin download failed" with `str(e)[:3900]` as description (truncation guards against Discord's 4096-char embed limit). Stops the silent-failure mode that motivated this PR.

## Test plan

- [x] Live-probed the WP REST endpoint — returns the 5/17/2026 bulletin (and 10 prior) sorted newest-first.
- [x] `python3 -m py_compile` passes for all three files.
- [x] Spec-compliance review ✅
- [x] Code-quality review ✅ after a hardening pass (timeouts, scheduled-path try/except, anchored slug match, embed truncation).
- [ ] Once merged + deployed: post "@here The bulletin has been posted for 5/24" in the read channel and confirm the bot replies with a status embed and `/status` shows `Bulletin: ✅`.
- [ ] Confirm the Thu/Fri/Sat 18:15 scheduled `check_for_latest_bulletin` runs cleanly against the new code path.

## Out of scope

Other refactor opportunities noted but intentionally not touched in this PR: the dead `schedule_tasks.scheduled_task` path, the `extractpdftext.py` → `pdf.txt` vs `bulletin.txt` filename split, deprecated `discord_slash` library, and the Buster-base `Dockerfile`.