### PR TITLE
Fix Docker build: bump base from EOL Buster to Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.9-slim-buster
-RUN apt-get update && apt-get install --no-install-recommends build-essential python-dev -y \
+FROM python:3.9-slim-bookworm
+RUN apt-get update && apt-get install --no-install-recommends build-essential python3-dev -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The merge of #197 triggered `DockerBuild_main` which failed at the `apt-get update` step:

```
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

Debian 10 (Buster) reached end-of-life and its package repositories have been moved to `archive.debian.org`. The base image `python:3.9-slim-buster` still pulls from Docker Hub, but any container that runs `apt-get update` against it now fails. This has nothing to do with the application code — it's pure infra rot from a pre-existing issue exposed by the next deploy attempt.

## Fix

Two small Dockerfile changes:

1. `python:3.9-slim-buster` → `python:3.9-slim-bookworm` (Debian 12, current stable, Python 3.9 image still maintained).
2. `python-dev` → `python3-dev`. The old `python-dev` package (a Python 2 era alias) doesn't exist in Bookworm; modern Debian uses `python3-dev` for the same headers.

`build-essential` is unchanged — kept because some pinned requirements (e.g. `PyMuPDF`, `pysftp` deps) may need native compilation.

## Test plan

- [ ] Merge → `DockerBuild_main` workflow runs and succeeds at the `apt-get install` step.
- [ ] Image deploys and the bot reconnects to Discord cleanly.
- [ ] First post of `"The bulletin has been posted"` after deploy triggers the new WP REST API path from #197 successfully.

## Follow-ups (not in this PR)

- Python 3.9 itself goes EOL in October 2025 — worth a separate PR to bump to 3.11 or 3.12 along with re-pinning `requirements.txt`. Higher risk because `discord_slash` and other older deps may not play well with newer Python.
- The Dockerfile still hardcodes empty `ENV` declarations for secrets (Docker linter warns on these) — cosmetic, not blocking.